### PR TITLE
Overhaul roster

### DIFF
--- a/Roster/roster.py
+++ b/Roster/roster.py
@@ -42,18 +42,17 @@ class Roster(commands.Cog):
             await ctx.send("This nation has already been recorded.")
         elif oldnation != "Null" and await self._isinwa(wanation=oldnation):
             await ctx.send("Make sure your old WA nation has successfully resigned.")
+        # Only reach if old is null / not in WA
+        #Checks that new nation is WA
+        elif not await self._isinwa(wanation=newnation):
+            await ctx.send("Make sure Nation given is in the WA")
         else:
-            # Only reach if old is null / not in WA
-            #Checks that new nation is WA
-            if await self._isinwa(wanation=newnation):
-                #Saves new WA in Roster
-                await self.config.user(user).userwa.set(newnation)
-                await self.config.user(user).name.set(user.display_name)
-                async with self.config.roster() as roster:
-                    roster.add(user.id)
-                await ctx.send("Your WA Nation has been set!")
-            else:
-                await ctx.send("Make sure Nation given is in the WA")
+            #Saves new WA in Roster
+            await self.config.user(user).userwa.set(newnation)
+            await self.config.user(user).name.set(user.display_name)
+            async with self.config.roster() as roster:
+                roster.add(user.id)
+            await ctx.send("Your WA Nation has been set!")
                 
     @commands.command()
     async def removewa(self, ctx):

--- a/Roster/roster.py
+++ b/Roster/roster.py
@@ -2,6 +2,7 @@ import dataclasses
 import discord
 import asyncio
 import sans
+import io
 import json
 from sans.api import Api
 from sans.errors import HTTPException, NotFound
@@ -10,13 +11,6 @@ from redbot.core import checks, commands, Config
 from redbot.core.utils.chat_formatting import pagify, escape, box
 from lxml import etree as ET
 from libneko import pag
-
-@dataclasses.dataclass
-class RosterEntry:
-    """One entry of the roster."""
-
-    name: str
-    wa: str
 
 class Roster(commands.Cog):
 
@@ -85,6 +79,21 @@ class Roster(commands.Cog):
         nav += tostring.strip('{}').replace('":',"\n").replace('",','\n').replace('"',"**").rstrip('\n').rstrip('*')
 
         nav.start(ctx)
+
+    @commands.command()
+    @commands.has_role("KPCmd")
+    async def rawroster(self, ctx: commands.Context) -> None:
+        """Output the roster in raw key-value format."""
+        # rosteritems = "\n".join(f"{name}={wa}" for userid, (name, wa) in (await self.config.roster()).items())
+        rosteritems = json.dumps({name: wa for (_, (name, wa)) in (await self.config.roster()).items()}, indent=4)
+        await ctx.send("Roster", file=discord.File(io.BytesIO(rosteritems.encode("utf-8")), filename="roster.json"))
+
+    @commands.command()
+    @commands.has_role("KPCmd")
+    async def clearroster(self, ctx: commands.Context) -> None:
+        """Clear all data from the roster."""
+        self.config.roster.set({})
+        await ctx.send("Roster cleared.")
 
     async def _isinwa(self, wanation: str) -> bool:
         """Check if Nation is in the WA"""

--- a/Roster/roster.py
+++ b/Roster/roster.py
@@ -79,8 +79,12 @@ class Roster(commands.Cog):
     
     @commands.group()
     @commands.has_role("KPCmd")
-    async def roster(self, ctx: commands.Context):
-        #Display current WA roster in flippable format
+    async def roster(self, ctx: commands.Context) -> None:
+        """Roster related command group."""
+
+    @roster.command()
+    async def show(self, ctx: commands.Context):
+        """Display current WA roster in flippable format."""
 
         if ctx.invoked_subcommand is None:
             rosterdict = await self._roster_map()

--- a/Roster/roster.py
+++ b/Roster/roster.py
@@ -92,7 +92,7 @@ class Roster(commands.Cog):
     @commands.has_role("KPCmd")
     async def clearroster(self, ctx: commands.Context) -> None:
         """Clear all data from the roster."""
-        self.config.roster.set({})
+        await self.config.roster.set({})
         await ctx.send("Roster cleared.")
 
     async def _isinwa(self, wanation: str) -> bool:

--- a/Roster/roster.py
+++ b/Roster/roster.py
@@ -1,3 +1,4 @@
+import dataclasses
 import discord
 import asyncio
 import sans
@@ -9,6 +10,13 @@ from redbot.core import checks, commands, Config
 from redbot.core.utils.chat_formatting import pagify, escape, box
 from lxml import etree as ET
 from libneko import pag
+
+@dataclasses.dataclass
+class RosterEntry:
+    """One entry of the roster."""
+
+    name: str
+    wa: str
 
 class Roster(commands.Cog):
 
@@ -47,7 +55,7 @@ class Roster(commands.Cog):
                 #Saves new WA in Roster
                 await self.config.user(user).userwa.set(newnation)
                 async with self.config.roster() as roster:
-                    roster[user.display_name] = newnation
+                    roster[user.id] = (user.display_name, newnation)
                     await ctx.send("Your WA Nation has been set!")
             else:
                 await ctx.send("Make sure Nation given is in the WA")
@@ -70,7 +78,7 @@ class Roster(commands.Cog):
     async def roster(self, ctx):
         #Display current WA roster in flippable format
 
-        rosterdict = await self.config.roster()
+        rosterdict = {name: wa for name, wa in (await self.config.roster()).values()}
         tostring = json.dumps(rosterdict, sort_keys=True, indent=0)
 
         nav = pag.EmbedNavigatorFactory(max_lines=30, prefix="__**TITO Roster**__", enable_truncation=True)

--- a/Roster/roster.py
+++ b/Roster/roster.py
@@ -8,6 +8,7 @@ import discord
 from libneko import pag
 from redbot.core import commands, Config
 
+import sans
 from sans.api import Api
 from sans.utils import pretty_string
 
@@ -50,7 +51,7 @@ class Roster(commands.Cog):
         # Only reach if old is null / not in WA
         # Checks that new nation is WA
         elif not await self._isinwa(wanation=newnation):
-            await ctx.send("Make sure Nation given is in the WA")
+            await ctx.send(f"Nation '{newnation}' is not in the WA.")
         else:
             # Saves new WA in Roster
             await self.config.user(user).userwa.set(newnation)
@@ -140,6 +141,10 @@ class Roster(commands.Cog):
             "wa",
             nation=wanation,
         )
-        root = await request
-        pretty = pretty_string(root)
-        return "wa" in pretty.lower()
+        try:
+            root = await request
+        except sans.errors.HTTPException:
+            return False
+        else:
+            pretty = pretty_string(root)
+            return "wa" in pretty.lower()


### PR DESCRIPTION
Made a few changes to the roster cog, mostly to improve the roster command experience but also a few pain points I've noticed with setting WA.

- Setting a new WA for the first time gives a confirmation message same as changing it.
- Setting WA to what it already is gives a custom message, instead of "resign old WA"
- Setting WA to a non-existent nation (e.g. by forgetting quotes) fails with a graceful message
- Make roster entries ID keyed instead of display name
- Make info only stored in user config and roster config is only a list of ID which are then used to output a roster
- Add commands to get raw roster output and to clear roster

Possible improvements:
- Make it possible for Command to manipulate individual roster entries
- Add load roster command (probably difficult due to needing to map names -> discord user)

Pretty sure that's about all that changed. I have moderately tested the changes on a personal red instance.

If merged, `roster clear` should probably be run immediately to refresh config data structure.