### PR TITLE
Tidy roster commands and add known and deployed commands

### DIFF
--- a/Roster/deployed.py
+++ b/Roster/deployed.py
@@ -1,0 +1,50 @@
+"""Use a roster file to find who is deployed in regions.
+
+Based on https://github.com/HN67/nsapi/blob/master/roster/deployed.py
+but adapted to work with sans."""
+
+import typing as t
+
+import sans
+from sans.api import Api
+from sans.utils import pretty_string
+
+
+def clean_format(nation: str) -> str:
+    """Converts a nation name to API form."""
+    return nation.replace(" ", "_").lower()
+
+
+async def endorsements(nation: str) -> t.Iterable[str]:
+    """Query NS API for the endorsements of a nation."""
+    Api.agent = "10000 Islands Discord Bot contact Kortexia"
+    request = Api(
+        "endorsements",
+        nation=nation,
+    )
+    try:
+        root = await request
+    except sans.errors.HTTPException:
+        return []
+    else:
+        pretty = pretty_string(root)
+        return pretty.split(",")
+
+
+async def deployed(
+    lead: str,
+    roster: t.Mapping[str, t.Iterable[str]],
+) -> t.Collection[str]:
+    """Determine who are deployed and endorsing the lead."""
+    # Obtain endorsement list of lead
+    endos = map(clean_format, await endorsements(lead))
+    # Invert roster into puppet -> main form
+    owners = {
+        clean_format(switcher): main
+        for main, switchers in roster.items()
+        for switcher in switchers
+    }
+    # Also include main nations
+    owners.update({main: main for main in roster.keys()})
+    # Return owners who have a nation endoing lead
+    return [owners[nation] for nation in endos if nation in owners]

--- a/Roster/deployed.py
+++ b/Roster/deployed.py
@@ -3,7 +3,6 @@
 Based on https://github.com/HN67/nsapi/blob/master/roster/deployed.py
 but adapted to work with sans."""
 
-import itertools
 import typing as t
 
 import sans
@@ -33,7 +32,7 @@ async def endorsements(nation: str) -> t.Iterable[str]:
 async def deployed(
     lead: str,
     roster: t.Mapping[str, t.Iterable[str]],
-) -> t.Tuple[t.Collection[str], t.Collection[str]]:
+) -> t.Tuple[t.Collection[t.Tuple[str, str]], t.Collection[str]]:
     """Determine who are deployed and endorsing the lead.
 
     Returns a tuple of those known to be deployed on and including the lead,
@@ -50,6 +49,9 @@ async def deployed(
     # Obtain endorsement list of lead
     endos = map(clean_format, await endorsements(lead))
     # We also want to include the lead in those deployed
-    deployed_puppets = itertools.chain(endos, [clean_format(lead)])
+    deployed_puppets = list(endos) + [clean_format(lead)]
     # Return owners who have a nation endoing lead
-    return [owners[nation] for nation in deployed_puppets if nation in owners], []
+    return (
+        [(owners[nation], nation) for nation in deployed_puppets if nation in owners],
+        [puppet for puppet in deployed_puppets if puppet not in owners],
+    )

--- a/Roster/roster.py
+++ b/Roster/roster.py
@@ -120,7 +120,7 @@ class Roster(commands.Cog):
     @roster.command()
     async def raw(self, ctx: commands.Context) -> None:
         """Output the roster in raw key-value format."""
-        rosteritems = json.dumps(await self._roster_map(), indent=4)
+        rosteritems = json.dumps(await self._roster_map(), indent=4, sort_keys=True)
         await ctx.send(
             "Roster",
             file=discord.File(

--- a/Roster/roster.py
+++ b/Roster/roster.py
@@ -82,9 +82,13 @@ class Roster(commands.Cog):
                     await ctx.send("No file attached, please rerun this command.")
                     return
         raw: bytes = await file.read()
-        known = json.loads(raw)
-        await self.config.known.set(known)
-        await ctx.send("Known list updated.")
+        try:
+            known = json.loads(raw)
+        except json.JSONDecodeError:
+            await ctx.send("Provided file is not well-formed JSON.")
+        else:
+            await self.config.known.set(known)
+            await ctx.send("Known list updated.")
 
     @known.command()
     async def export(self, ctx: commands.Context, sort: bool = True) -> None:

--- a/Roster/roster.py
+++ b/Roster/roster.py
@@ -222,8 +222,6 @@ class Roster(commands.Cog):
     @roster.command()
     async def clear(self, ctx: commands.Context) -> None:
         """Clear all data from the roster."""
-        # Yes this wipes all config data for this Cog,
-        # which should only be WA and roster list.
         timeout = 5
         await ctx.send(
             f"Confirmation required; type 'confirm' within {timeout} seconds."
@@ -243,8 +241,11 @@ class Roster(commands.Cog):
         else:
             # checking for 'confirm' is done in the wait_for predicate
             # so at this point in code we can clear
-            await self.config.clear_all()
-            await ctx.send("Roster cleared.")
+            # we only clear the roster and user data,
+            # we don't want to clear the known data
+            await self.config.roster.clear()
+            await self.config.clear_all_users()
+            await ctx.send("Roster list and user WAs cleared.")
 
     async def _isinwa(self, wanation: str) -> bool:
         """Check if Nation is in the WA"""

--- a/Roster/roster.py
+++ b/Roster/roster.py
@@ -47,9 +47,13 @@ class Roster(commands.Cog):
         self.config.register_global(roster={}, known={})
         self.config.register_user(userwa="Null", name="Null")
 
-    @commands.command()
+    @commands.group()
     @commands.has_role("KPCmd")
-    async def importknown(self, ctx: commands.Context) -> None:
+    async def known(self, ctx: commands.Context) -> None:
+        """Command group for managing a list of known puppets."""
+
+    @known.command()
+    async def upload(self, ctx: commands.Context) -> None:
         """Import the JSON file attached to this command,
         or wait for a file to be uploaded after the command is run.
 
@@ -82,9 +86,8 @@ class Roster(commands.Cog):
         await self.config.known.set(known)
         await ctx.send("Known list updated.")
 
-    @commands.command()
-    @commands.has_role("KPCmd")
-    async def exportknown(self, ctx: commands.Context, sort: bool = True) -> None:
+    @known.command()
+    async def export(self, ctx: commands.Context, sort: bool = True) -> None:
         """Export known puppets as JSON."""
         known = json.dumps(await self.config.known(), indent=4, sort_keys=sort)
         await ctx.send(

--- a/Roster/roster.py
+++ b/Roster/roster.py
@@ -1,5 +1,6 @@
 """Manage a WA roster."""
 
+import asyncio
 import io
 import json
 import typing as t
@@ -131,8 +132,21 @@ class Roster(commands.Cog):
         """Clear all data from the roster."""
         # Yes this wipes all config data for this Cog,
         # which should only be WA and roster list.
-        await self.config.clear_all()
-        await ctx.send("Roster cleared.")
+        timeout = 5
+        await ctx.send(f"Confirmation required; type 'confirm' within {timeout} seconds.")
+        try:
+            await self.bot.wait_for(
+                "message",
+                check=(lambda msg: msg.channel == ctx.channel and msg.author == ctx.author and msg.content.strip().lower() == "confirm"),
+                timeout=timeout
+            )
+            # checking for 'confirm' is done in the wait_for predicate
+            # so at this point in code we can clear
+            await self.config.clear_all()
+            await ctx.send("Roster cleared.")
+        except asyncio.TimeoutError:
+            await ctx.send("Timeout passed, roster not cleared.")
+       
 
     async def _isinwa(self, wanation: str) -> bool:
         """Check if Nation is in the WA"""

--- a/Roster/roster.py
+++ b/Roster/roster.py
@@ -17,6 +17,8 @@ from sans.utils import pretty_string
 # from redbot.core.utils.chat_formatting import pagify, escape, box
 # from sans.errors import HTTPException, NotFound
 
+from . import deployed
+
 
 def channel_and_author(ctx: commands.Context) -> t.Callable[[discord.Message], bool]:
     """Construct a predicate that checks author and channel to be same as context."""
@@ -89,6 +91,15 @@ class Roster(commands.Cog):
             "Known",
             file=discord.File(io.BytesIO(known.encode("utf-8")), filename="known.json"),
         )
+
+    @commands.command()
+    @commands.has_role("KPCmd")
+    async def deployed(self, ctx: commands.Context, lead: str) -> None:
+        """Check who is deployed on a lead, according to loaded known file."""
+        endorsers = await deployed.deployed(
+            lead=lead, roster=(await self.config.known())
+        )
+        await ctx.send(f"Deployed: {','.join(endorsers)}")
 
     @commands.command()
     @commands.has_role("TITO Member")

--- a/Roster/roster.py
+++ b/Roster/roster.py
@@ -32,70 +32,9 @@ class Roster(commands.Cog):
         # Setup config structure
         self.config = Config.get_conf(self, identifier=31415926535)
         default_global = {"roster": {}}
-        default_user = {"userwa": "Null", "name": "Null", "nations": {}}
+        default_user = {"userwa": "Null", "name": "Null"}
         self.config.register_global(**default_global)
         self.config.register_user(**default_user)
-
-    @commands.command()
-    @commands.has_role("TITO Member")
-    async def addnation(
-        self, ctx: commands.Context, nation: str, user: discord.Member = None
-    ) -> None:
-        """Register one of your nations to be tracked."""
-        # Command can act on other members
-        if not (user and discord.utils.get(ctx.author.roles, name="KPCmd")):
-            user = ctx.message.author
-        async with self.config.user(user).nations() as nations:
-            if nation in nations:
-                await ctx.send(
-                    f"Nation '{nation}' was already tracked for {user.display_name}."
-                )
-            else:
-                nations[nation] = True
-                await ctx.send(f"Nation '{nation}' added for {user.display_name}.")
-
-    @commands.command()
-    @commands.has_role("TITO Member")
-    async def removenation(
-        self, ctx: commands.Context, nation: str, user: discord.Member = None
-    ) -> None:
-        """Register one of your nations to be tracked."""
-        # Command can act on other members
-        if not (user and discord.utils.get(ctx.author.roles, name="KPCmd")):
-            user = ctx.message.author
-        async with self.config.user(user).nations() as nations:
-            try:
-                del nations[nation]
-            except KeyError:
-                await ctx.send(
-                    f"Nation '{nation}' was not tracked for {user.display_name}."
-                )
-            else:
-                await ctx.send(f"Nation '{nation}' removed for {user.display_name}.")
-
-    @commands.command()
-    @commands.has_role("TITO Member")
-    async def listnations(
-        self, ctx: commands.Context, user: discord.Member = None
-    ) -> None:
-        """List all of your tracked nations."""
-        # Command can act on other members
-        if not (user and discord.utils.get(ctx.author.roles, name="KPCmd")):
-            user = ctx.message.author
-        await ctx.send(str(list((await self.config.user(user).nations()).keys())))
-
-    @commands.command()
-    @commands.has_role("TITO Member")
-    async def markwa(
-        self, ctx: commands.Context, nation: str, user: discord.Member = None
-    ) -> None:
-        """Mark a nation as a possible future WA in the roster."""
-        # Command can act on other members
-        if not (user and discord.utils.get(ctx.author.roles, name="KPCmd")):
-            user = ctx.message.author
-            async with self.config.user(user).nations() as nations:
-                nations[nation] = True
-                await ctx.send(f"Nation '{nation}' has been marked for {user.display_name}.")
 
     @commands.command()
     @commands.has_role("TITO Member")

--- a/Roster/roster.py
+++ b/Roster/roster.py
@@ -47,7 +47,9 @@ class Roster(commands.Cog):
             user = ctx.message.author
         async with self.config.user(user).nations() as nations:
             if nation in nations:
-                await ctx.send(f"Nation '{nation}' was already tracked for {user.display_name}.")
+                await ctx.send(
+                    f"Nation '{nation}' was already tracked for {user.display_name}."
+                )
             else:
                 nations[nation] = True
                 await ctx.send(f"Nation '{nation}' added for {user.display_name}.")
@@ -70,6 +72,30 @@ class Roster(commands.Cog):
                 )
             else:
                 await ctx.send(f"Nation '{nation}' removed for {user.display_name}.")
+
+    @commands.command()
+    @commands.has_role("TITO Member")
+    async def listnations(
+        self, ctx: commands.Context, user: discord.Member = None
+    ) -> None:
+        """List all of your tracked nations."""
+        # Command can act on other members
+        if not (user and discord.utils.get(ctx.author.roles, name="KPCmd")):
+            user = ctx.message.author
+        await ctx.send(str(list((await self.config.user(user).nations()).keys())))
+
+    @commands.command()
+    @commands.has_role("TITO Member")
+    async def markwa(
+        self, ctx: commands.Context, nation: str, user: discord.Member = None
+    ) -> None:
+        """Mark a nation as a possible future WA in the roster."""
+        # Command can act on other members
+        if not (user and discord.utils.get(ctx.author.roles, name="KPCmd")):
+            user = ctx.message.author
+            async with self.config.user(user).nations() as nations:
+                nations[nation] = True
+                await ctx.send(f"Nation '{nation}' has been marked for {user.display_name}.")
 
     @commands.command()
     @commands.has_role("TITO Member")

--- a/Roster/roster.py
+++ b/Roster/roster.py
@@ -62,7 +62,7 @@ class Roster(commands.Cog):
             await self.config.user(user).userwa.set(newnation)
             await self.config.user(user).name.set(user.display_name)
             async with self.config.roster() as roster:
-                roster[user.id] = True
+                roster[str(user.id)] = True
             await ctx.send("Your WA Nation has been set!")
 
     @commands.command()
@@ -74,7 +74,9 @@ class Roster(commands.Cog):
             user = ctx.message.author
         await self.config.user(user).clear()
         async with self.config.roster() as roster:
-            roster.pop(user.id, None)
+            # config mappings use string keys
+            roster.pop(str(user.id), None)
+        await ctx.send("Your WA Nation has been removed.")
 
     @commands.command()
     @commands.has_role("TITO Member")
@@ -93,7 +95,7 @@ class Roster(commands.Cog):
             (await self.config.user_from_id(user_id).name()): (
                 await self.config.user_from_id(user_id).userwa()
             )
-            for user_id in (await (self.config.roster())).keys()
+            for user_id in map(int, (await (self.config.roster())).keys())
         }
 
     @commands.group()

--- a/Roster/roster.py
+++ b/Roster/roster.py
@@ -82,8 +82,9 @@ class Roster(commands.Cog):
     async def _roster_map(self) -> t.Mapping[str, str]:
         """Construct a name -> WA mapping of roster members."""
         return {
-            (await self.config.user_from_id(user_id).name())
-            : (await self.config.user_from_id(user_id).userwa())
+            (await self.config.user_from_id(user_id).name()): (
+                await self.config.user_from_id(user_id).userwa()
+            )
             for user_id in (await (self.config.roster())).keys()
         }
 

--- a/Roster/roster.py
+++ b/Roster/roster.py
@@ -38,10 +38,14 @@ class Roster(commands.Cog):
 
     @commands.command()
     @commands.has_role("TITO Member")
-    async def setwa(self, ctx: commands.Context, newnation: str) -> None:
+    async def setwa(
+        self, ctx: commands.Context, newnation: str, user: discord.Member = None
+    ) -> None:
         """Set your WA in the roster."""
 
-        user = ctx.message.author
+        # Command can use setwa on other members
+        if not (user and discord.utils.get(ctx.author.roles, name="KPCmd")):
+            user = ctx.message.author
 
         # Checks that previous nation is no longer WA
         oldnation = await self.config.user(user).userwa()
@@ -63,18 +67,22 @@ class Roster(commands.Cog):
 
     @commands.command()
     @commands.has_role("TITO Member")
-    async def removewa(self, ctx: commands.Context) -> None:
+    async def removewa(self, ctx: commands.Context, user: discord.Member = None) -> None:
         """Remove your WA from the roster."""
-        user = ctx.message.author
+        # Command can use removewa on other members
+        if not (user and discord.utils.get(ctx.author.roles, name="KPCmd")):
+            user = ctx.message.author
         await self.config.user(user).clear()
         async with self.config.roster() as roster:
             roster.pop(user.id, None)
 
     @commands.command()
     @commands.has_role("TITO Member")
-    async def checkwa(self, ctx: commands.Context) -> None:
+    async def checkwa(self, ctx: commands.Context, user: discord.Member = None) -> None:
         """Check you WA in the roster."""
-        user = ctx.message.author
+        # Command can use checkwa on other members
+        if not (user and discord.utils.get(ctx.author.roles, name="KPCmd")):
+            user = ctx.message.author
         # Lists current WA nation for self
         currentwa = await self.config.user(user).userwa()
         await ctx.send(currentwa)

--- a/Roster/roster.py
+++ b/Roster/roster.py
@@ -96,10 +96,17 @@ class Roster(commands.Cog):
     @commands.has_role("KPCmd")
     async def deployed(self, ctx: commands.Context, lead: str) -> None:
         """Check who is deployed on a lead, according to loaded known file."""
-        endorsers, _ = await deployed.deployed(
+        endorsers, unknown = await deployed.deployed(
             lead=lead, roster=(await self.config.known())
         )
-        content = ", ".join(sorted(endorsers))
+        # yeah this works. zip(*iterable) is its own inverse
+        # kinda mind bending but it checks out
+        endorser_names, endorser_puppets = zip(*sorted(endorsers))
+        content = "Known: {known}\nKnown Puppets: {puppets}\nUnknown: {unknown}".format(
+            known=", ".join(endorser_names),
+            puppets=", ".join(endorser_puppets),
+            unknown=", ".join(unknown),
+        )
         await ctx.send(
             f"Deployed on {lead}:",
             file=discord.File(

--- a/Roster/roster.py
+++ b/Roster/roster.py
@@ -32,9 +32,46 @@ class Roster(commands.Cog):
         # Setup config structure
         self.config = Config.get_conf(self, identifier=31415926535)
         default_global = {"roster": {}}
-        default_user = {"userwa": "Null", "name": "Null"}
+        default_user = {"userwa": "Null", "name": "Null", "nations": []}
         self.config.register_global(**default_global)
         self.config.register_user(**default_user)
+
+    @commands.command()
+    @commands.has_role("TITO Member")
+    async def addnation(
+        self, ctx: commands.Context, nation: str, user: discord.Member = None
+    ) -> None:
+        """Register one of your nations to be tracked."""
+        # Command can act on other members
+        if not (user and discord.utils.get(ctx.author.roles, name="KPCmd")):
+            user = ctx.message.author
+        async with self.config.user(user).nations as nations:
+            if nation not in nations:
+                nations.append(nation)
+                await ctx.send(f"Nation '{nation}' added for {user.display_name}.")
+            else:
+                await ctx.send(
+                    f"Nation '{nation}' already added for {user.display_name}."
+                )
+
+    @commands.command()
+    @commands.has_role("TITO Member")
+    async def removenation(
+        self, ctx: commands.Context, nation: str, user: discord.Member = None
+    ) -> None:
+        """Register one of your nations to be tracked."""
+        # Command can act on other members
+        if not (user and discord.utils.get(ctx.author.roles, name="KPCmd")):
+            user = ctx.message.author
+        async with self.config.user(user).nations as nations:
+            try:
+                nations.remove(nation)
+            except ValueError:
+                await ctx.send(
+                    f"Nation '{nation}' was not tracked for {user.display_name}."
+                )
+            else:
+                await ctx.send(f"Nation '{nation}' removed for {user.display_name}.")
 
     @commands.command()
     @commands.has_role("TITO Member")
@@ -67,7 +104,9 @@ class Roster(commands.Cog):
 
     @commands.command()
     @commands.has_role("TITO Member")
-    async def removewa(self, ctx: commands.Context, user: discord.Member = None) -> None:
+    async def removewa(
+        self, ctx: commands.Context, user: discord.Member = None
+    ) -> None:
         """Remove your WA from the roster."""
         # Command can use removewa on other members
         if not (user and discord.utils.get(ctx.author.roles, name="KPCmd")):

--- a/Roster/roster.py
+++ b/Roster/roster.py
@@ -96,10 +96,17 @@ class Roster(commands.Cog):
     @commands.has_role("KPCmd")
     async def deployed(self, ctx: commands.Context, lead: str) -> None:
         """Check who is deployed on a lead, according to loaded known file."""
-        endorsers = await deployed.deployed(
+        endorsers, _ = await deployed.deployed(
             lead=lead, roster=(await self.config.known())
         )
-        await ctx.send(f"Deployed: {','.join(endorsers)}")
+        content = ", ".join(sorted(endorsers))
+        await ctx.send(
+            f"Deployed on {lead}:",
+            file=discord.File(
+                io.BytesIO(content.encode("utf-8")),
+                filename=f"deployed_{deployed.clean_format(lead)}.txt",
+            ),
+        )
 
     @commands.command()
     @commands.has_role("TITO Member")

--- a/Roster/roster.py
+++ b/Roster/roster.py
@@ -32,7 +32,7 @@ class Roster(commands.Cog):
         # Setup config structure
         self.config = Config.get_conf(self, identifier=31415926535)
         default_global = {"roster": {}}
-        default_user = {"userwa": "Null", "name": "Null", "nations": []}
+        default_user = {"userwa": "Null", "name": "Null", "nations": {}}
         self.config.register_global(**default_global)
         self.config.register_user(**default_user)
 
@@ -45,14 +45,12 @@ class Roster(commands.Cog):
         # Command can act on other members
         if not (user and discord.utils.get(ctx.author.roles, name="KPCmd")):
             user = ctx.message.author
-        async with self.config.user(user).nations as nations:
-            if nation not in nations:
-                nations.append(nation)
-                await ctx.send(f"Nation '{nation}' added for {user.display_name}.")
+        async with self.config.user(user).nations() as nations:
+            if nation in nations:
+                await ctx.send(f"Nation '{nation}' was already tracked for {user.display_name}.")
             else:
-                await ctx.send(
-                    f"Nation '{nation}' already added for {user.display_name}."
-                )
+                nations[nation] = True
+                await ctx.send(f"Nation '{nation}' added for {user.display_name}.")
 
     @commands.command()
     @commands.has_role("TITO Member")
@@ -63,10 +61,10 @@ class Roster(commands.Cog):
         # Command can act on other members
         if not (user and discord.utils.get(ctx.author.roles, name="KPCmd")):
             user = ctx.message.author
-        async with self.config.user(user).nations as nations:
+        async with self.config.user(user).nations() as nations:
             try:
-                nations.remove(nation)
-            except ValueError:
+                del nations[nation]
+            except KeyError:
                 await ctx.send(
                     f"Nation '{nation}' was not tracked for {user.display_name}."
                 )

--- a/Roster/roster.py
+++ b/Roster/roster.py
@@ -134,20 +134,26 @@ class Roster(commands.Cog):
         # Yes this wipes all config data for this Cog,
         # which should only be WA and roster list.
         timeout = 5
-        await ctx.send(f"Confirmation required; type 'confirm' within {timeout} seconds.")
+        await ctx.send(
+            f"Confirmation required; type 'confirm' within {timeout} seconds."
+        )
         try:
             await self.bot.wait_for(
                 "message",
-                check=(lambda msg: msg.channel == ctx.channel and msg.author == ctx.author and msg.content.strip().lower() == "confirm"),
-                timeout=timeout
+                check=(
+                    lambda msg: msg.channel == ctx.channel
+                    and msg.author == ctx.author
+                    and msg.content.strip().lower() == "confirm"
+                ),
+                timeout=timeout,
             )
+        except asyncio.TimeoutError:
+            await ctx.send("Timeout passed, roster not cleared.")
+        else:
             # checking for 'confirm' is done in the wait_for predicate
             # so at this point in code we can clear
             await self.config.clear_all()
             await ctx.send("Roster cleared.")
-        except asyncio.TimeoutError:
-            await ctx.send("Timeout passed, roster not cleared.")
-       
 
     async def _isinwa(self, wanation: str) -> bool:
         """Check if Nation is in the WA"""


### PR DESCRIPTION
You can get a pretty good changelog from the commit titles, except a couple commits were basically reverted later on.

Changes:
 - Make clearing the roster require confirmation within 5 seconds
 - Make the raw roster output sorted
 - Allow Command to set and check WA for other members
 - Fix removewa leaving a null entry in the roster list
 - Add two commands to upload and export a roster of known puppets
 - Add a command `deployed` that checks who endorsing a lead is known and unknown

